### PR TITLE
fix: Update Plinko game based on your feedback

### DIFF
--- a/plinko/plinko.css
+++ b/plinko/plinko.css
@@ -11,7 +11,7 @@ body {
 }
 
 #game-container {
-    max-width: 600px;
+    max-width: 800px; /* Increased from 600px */
     background-color: #fff;
     padding: 20px;
     border-radius: 8px;
@@ -20,8 +20,8 @@ body {
 }
 
 #plinko-board {
-    width: 500px;
-    height: 400px;
+    width: 700px; /* Increased from 500px */
+    height: 600px; /* Increased from 400px */
     border: 2px solid #333;
     position: relative;
     margin: 20px auto;

--- a/plinko/plinko.html
+++ b/plinko/plinko.html
@@ -13,11 +13,19 @@
         </div>
         <div id="ball"></div>
         <div id="prize-slots">
-            <div class="prize-slot">Prize 1</div>
-            <div class="prize-slot">Prize 2</div>
-            <div class="prize-slot">Prize 3</div>
-            <div class="prize-slot">Prize 4</div>
-            <div class="prize-slot">Prize 5</div>
+            <div class="prize-slot">x33</div>
+            <div class="prize-slot">x11</div>
+            <div class="prize-slot">x4</div>
+            <div class="prize-slot">x2</div>
+            <div class="prize-slot">x1.1</div>
+            <div class="prize-slot">x0.6</div>
+            <div class="prize-slot">x0.3</div>
+            <div class="prize-slot">x0.6</div>
+            <div class="prize-slot">x1.1</div>
+            <div class="prize-slot">x2</div>
+            <div class="prize-slot">x4</div>
+            <div class="prize-slot">x11</div>
+            <div class="prize-slot">x33</div>
         </div>
         <div id="score-display">Score: 0</div>
         <div id="message-display"></div>

--- a/plinko/plinko.js
+++ b/plinko/plinko.js
@@ -4,11 +4,12 @@
 window.plinkoGameApi = {};
 
 // --- Constants and Variables ---
-const PEG_ROWS = 10;
-const PEGS_PER_ROW_START = 7;
+// Adjusted for larger board (700x600px)
+const PEG_ROWS = 15; // Increased from 10
+const PEGS_PER_ROW_START = 10; // Increased from 7
 const PEG_SIZE = 10; // px
-const PEG_SPACING_HORIZONTAL = 60; // px
-const PEG_SPACING_VERTICAL = 35; // px
+const PEG_SPACING_HORIZONTAL = 60; // px (kept same)
+const PEG_SPACING_VERTICAL = 35; // px (kept same)
 const BALL_SIZE = 20; // px
 const BALL_START_OFFSET_Y = - (PEG_SPACING_VERTICAL / 2);
 
@@ -30,8 +31,8 @@ let ballVX, ballVY;
 let isDropping = false;
 let animationFrameId = null;
 
-// Prize values - made accessible for testing determinePrize
-const PRIZE_VALUES = [10, 25, 5, 50, 10, 25, 5]; // Ensure enough values if slots change
+// Prize values - updated to 13 slots, representing multipliers
+const PRIZE_VALUES = [33, 11, 4, 2, 1.1, 0.6, 0.3, 0.6, 1.1, 2, 4, 11, 33];
 
 
 // --- Sound Effect Placeholders ---
@@ -222,28 +223,40 @@ function updateGameInternal() {
 function determinePrizeInternal(finalBallX) {
     // Use the passed finalBallX for prize determination
     const currentBoardWidth = boardElement ? boardElement.clientWidth : 500; // Use actual or default
-    const prizeSlotsCount = boardElement ? document.querySelectorAll('#prize-slots .prize-slot').length : 5;
+    const prizeSlotsCount = boardElement ? document.querySelectorAll('#prize-slots .prize-slot').length : PRIZE_VALUES.length;
     const slotWidth = currentBoardWidth / prizeSlotsCount;
-    const slotIndex = Math.min(Math.floor(finalBallX / slotWidth), prizeSlotsCount - 1);
+    // Ensure slotIndex is within bounds of the PRIZE_VALUES array
+    const slotIndex = Math.max(0, Math.min(Math.floor(finalBallX / slotWidth), prizeSlotsCount - 1));
 
-    const wonAmount = PRIZE_VALUES[slotIndex % PRIZE_VALUES.length];
+    const prizeMultiplier = PRIZE_VALUES[slotIndex];
+    const wonAmount = Math.round(COST_TO_PLAY * prizeMultiplier); // Calculate actual points won
 
     playerScore += wonAmount;
     if(scoreDisplay) updateScoreDisplayInternal();
 
     if (messageDisplay) {
-        if (wonAmount > 0) {
-            messageDisplay.textContent = `Congratulations! You won ${wonAmount} points!`;
+        // Distinguish between actual win, break-even (e.g. x1 multiplier), or loss
+        if (prizeMultiplier > 1) {
+            messageDisplay.textContent = `Congratulations! You won ${wonAmount} points (x${prizeMultiplier})!`;
             messageDisplay.style.color = "blue";
             playSound_winPrize();
-        } else {
+        } else if (prizeMultiplier === 1) {
+            messageDisplay.textContent = `You got your ${COST_TO_PLAY} points back (x1).`;
+            messageDisplay.style.color = "green";
+            // playSound_neutral or playSound_losePrize could be used
+            playSound_losePrize();
+        } else if (prizeMultiplier > 0) { // Won something, but less than cost
+             messageDisplay.textContent = `You won ${wonAmount} points (x${prizeMultiplier}).`;
+            messageDisplay.style.color = "orange";
+            playSound_losePrize();
+        } else { // Multiplier is 0 or less (though current array is all positive)
             messageDisplay.textContent = "No prize this time. Better luck next drop!";
             messageDisplay.style.color = "orange";
             playSound_losePrize();
         }
     }
-    // console.log(`Ball landed at X: ${finalBallX.toFixed(2)}, slot: ${slotIndex + 1}, won: ${wonAmount}`);
-    return wonAmount; // Return for testing
+    // console.log(`Ball landed at X: ${finalBallX.toFixed(2)}, slot: ${slotIndex + 1}, multiplier: ${prizeMultiplier}, won: ${wonAmount}`);
+    return wonAmount; // Return for testing (actual points won)
 }
 
 function updateScoreDisplayInternal() {

--- a/plinko/tests/test_plinko.js
+++ b/plinko/tests/test_plinko.js
@@ -104,30 +104,45 @@ function runPlinkoTests() {
     // --- Test Prize Determination (Simplified) ---
     testResultsDiv.innerHTML += '<h4>Prize Determination Tests:</h4>';
     const prizeValues = initialState.PRIZE_VALUES;
-    const numSlots = document.querySelectorAll('#prize-slots .prize-slot').length || 5; // Match game logic
-    const mockBoardWidth = 500; // Must match what determinePrizeInternal expects or uses by default
+    const numSlots = document.querySelectorAll('#prize-slots .prize-slot').length || initialState.PRIZE_VALUES.length; // Use PRIZE_VALUES.length as fallback
+    const mockBoardWidth = 700; // Updated to match new board width and test_runner.html mock
 
     // Test landing in first slot
     window.plinkoGameApi.setPlayerScore(100); // Reset score
+    const costToPlay = initialState.COST_TO_PLAY;
     let ballX_slot1 = (mockBoardWidth / numSlots) * 0.5; // Middle of first slot
-    let prize1 = window.plinkoGameApi.determinePrize(ballX_slot1);
-    assertEquals(prizeValues[0], prize1, `Prize for slot 1 (X=${ballX_slot1.toFixed(0)}) should be ${prizeValues[0]}`);
-    assertEquals(100 + prizeValues[0], window.plinkoGameApi.getGameState().playerScore, "Score should update correctly for prize 1");
+    let wonAmount1 = window.plinkoGameApi.determinePrize(ballX_slot1);
+    let expectedWonAmount1 = Math.round(costToPlay * prizeValues[0]);
+    assertEquals(expectedWonAmount1, wonAmount1, `Points for slot 1 (multiplier ${prizeValues[0]}, X=${ballX_slot1.toFixed(0)}) should be ${expectedWonAmount1}`);
+    assertEquals(100 + expectedWonAmount1, window.plinkoGameApi.getGameState().playerScore, "Score should update correctly for prize 1");
 
-    // Test landing in third slot
+    // Test landing in third slot (multiplier prizeValues[2])
     window.plinkoGameApi.setPlayerScore(100); // Reset score
     let ballX_slot3 = (mockBoardWidth / numSlots) * 2.5; // Middle of third slot
-    let prize3 = window.plinkoGameApi.determinePrize(ballX_slot3);
+    let wonAmount3 = window.plinkoGameApi.determinePrize(ballX_slot3);
     const expectedPrizeIndex = 2; // 0-indexed
-    assertEquals(prizeValues[expectedPrizeIndex], prize3, `Prize for slot 3 (X=${ballX_slot3.toFixed(0)}) should be ${prizeValues[expectedPrizeIndex]}`);
-    assertEquals(100 + prizeValues[expectedPrizeIndex], window.plinkoGameApi.getGameState().playerScore, "Score should update correctly for prize 3");
+    let expectedWonAmount3 = Math.round(costToPlay * prizeValues[expectedPrizeIndex]);
+    assertEquals(expectedWonAmount3, wonAmount3, `Points for slot 3 (multiplier ${prizeValues[expectedPrizeIndex]}, X=${ballX_slot3.toFixed(0)}) should be ${expectedWonAmount3}`);
+    assertEquals(100 + expectedWonAmount3, window.plinkoGameApi.getGameState().playerScore, "Score should update correctly for prize 3");
 
-    // Test landing at the very edge (last slot)
+    // Test landing at the very edge (last slot, multiplier prizeValues[numSlots-1])
     window.plinkoGameApi.setPlayerScore(100);
     let ballX_lastSlot = mockBoardWidth - 1; // Almost at the very end, should be last slot
-    let prizeLast = window.plinkoGameApi.determinePrize(ballX_lastSlot);
-    assertEquals(prizeValues[numSlots - 1], prizeLast, `Prize for last slot (X=${ballX_lastSlot}) should be ${prizeValues[numSlots-1]}`);
-    assertEquals(100 + prizeValues[numSlots - 1], window.plinkoGameApi.getGameState().playerScore, "Score should update correctly for last prize slot");
+    let wonAmountLast = window.plinkoGameApi.determinePrize(ballX_lastSlot);
+    let expectedWonAmountLast = Math.round(costToPlay * prizeValues[numSlots - 1]);
+    assertEquals(expectedWonAmountLast, wonAmountLast, `Points for last slot (multiplier ${prizeValues[numSlots-1]}, X=${ballX_lastSlot}) should be ${expectedWonAmountLast}`);
+    assertEquals(100 + expectedWonAmountLast, window.plinkoGameApi.getGameState().playerScore, "Score should update correctly for last prize slot");
+
+    // Test a slot with a fractional multiplier (e.g., 0.3, which is PRIZE_VALUES[6])
+    // Assuming numSlots is 13, slot index 6 is the 7th slot.
+    if (numSlots === 13 && prizeValues.length === 13) {
+        window.plinkoGameApi.setPlayerScore(100);
+        let ballX_slot7 = (mockBoardWidth / numSlots) * 6.5; // Middle of 7th slot (index 6)
+        let wonAmount7 = window.plinkoGameApi.determinePrize(ballX_slot7);
+        let expectedWonAmount7 = Math.round(costToPlay * prizeValues[6]);
+        assertEquals(expectedWonAmount7, wonAmount7, `Points for slot 7 (multiplier ${prizeValues[6]}, X=${ballX_slot7.toFixed(0)}) should be ${expectedWonAmount7}`);
+        assertEquals(100 + expectedWonAmount7, window.plinkoGameApi.getGameState().playerScore, "Score should update correctly for slot 7 (fractional multiplier)");
+    }
 
 
     // --- Test Ball Reset ---

--- a/plinko/tests/test_runner.html
+++ b/plinko/tests/test_runner.html
@@ -40,7 +40,7 @@
 
     <!-- Mock HTML elements required by plinko.js for it to run without error, even if not visible -->
     <div id="game-container" style="display: none;">
-        <div id="plinko-board" style="width: 500px; height: 400px;"></div>
+        <div id="plinko-board" style="width: 700px; height: 600px;"></div> <!-- Updated width -->
         <div id="ball"></div>
         <div id="prize-slots">
             <div class="prize-slot">1</div>


### PR DESCRIPTION
This commit addresses your feedback to improve the Plinko game experience and configuration:

- **Prize Structure Updated:**
    - Number of prize slots increased to 13.
    - Prize multipliers updated to: 33x, 11x, 4x, 2x, 1.1x, 0.6x, 0.3x, 0.6x, 1.1x, 2x, 4x, 11x, 33x.
    - Prize calculation logic and display messages adjusted accordingly.

- **Game Board Enlarged:**
    - Plinko board width increased to 700px (was 500px) and height to 600px (was 400px).
    - Game container max-width increased to 800px.
    - Peg layout (rows and starting pegs per row) adjusted to better fit the larger board (15 rows, 10 starting pegs).

- **Ball Containment Verified:**
    - Confirmed that ball physics correctly use dynamic board dimensions, ensuring the ball remains within the enlarged game board boundaries.

- **Unit Tests Updated:**
    - Tests for prize determination now use the new 700px board width and 13 prize slots/values.
    - Mock HTML in the test runner updated to reflect new board dimensions.
    - Peg creation tests confirmed to be adaptive to new peg configuration constants.